### PR TITLE
Implementation of alternative contour intervall through parameter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -677,7 +677,7 @@ fn smoothjoin(thread: &String) -> Result<(), Box<dyn Error>>  {
         indexcontours = 5.0 * contour_intervall;
     }
 
-    let interval = 2.5 * halfintervall;
+    let interval = halfintervall;
     let path = format!("{}/xyz_knolls.xyz", tmpfolder);
     let xyz_file_in = Path::new(&path);
     let mut size: f64 = f64::NAN;

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,7 +238,9 @@ zoffset=0
 # Settings specific to rusty-pullauta
 jarkkos2019=1
 vege_bitmode=0
+vegeonly=0
 yellow_smoothing=0
+contour_intervall=5
 ".as_bytes()).expect("Cannot write file");
     }
 
@@ -604,7 +606,10 @@ fn process_tile(thread: &String, filename: &str, skip_rendering: bool) -> Result
     }
 
     fs::copy(format!("{}/xyz_03.xyz", tmpfolder), format!("{}/xyz2.xyz", tmpfolder)).expect("Could not copy file");
-    
+
+    let contour_intervall: f64 = conf.general_section().get("contour_intervall").unwrap_or("5").parse::<f64>().unwrap_or(5.0);
+    let halfintervall = contour_intervall / 2.0 * scalefactor;
+	
     if !vegeonly {
         let basemapcontours: f64 = conf.general_section().get("basemapinterval").unwrap_or("0").parse::<f64>().unwrap_or(0.0);
         if basemapcontours != 0.0 {
@@ -621,9 +626,9 @@ fn process_tile(thread: &String, filename: &str, skip_rendering: bool) -> Result
         println!("Contour generation part 2");
         if !skipknolldetection {
             // contours 2.5
-            xyz2contours(thread, 2.5 * scalefactor, "xyz_knolls.xyz", "null", "out.dxf", false).unwrap();
+            xyz2contours(thread, halfintervall, "xyz_knolls.xyz", "null", "out.dxf", false).unwrap();
         } else {
-            xyz2contours(thread, 2.5 * scalefactor, "xyztemp.xyz", "null", "out.dxf", true).unwrap();
+            xyz2contours(thread, halfintervall, "xyztemp.xyz", "null", "out.dxf", true).unwrap();
         }
         println!("Contour generation part 3");
         smoothjoin(thread).unwrap();
@@ -666,12 +671,13 @@ fn smoothjoin(thread: &String) -> Result<(), Box<dyn Error>>  {
     let mut indexcontours: f64 = conf.general_section().get("indexcontours").unwrap_or("12.5").parse::<f64>().unwrap_or(12.5);
     let formline: f64 = conf.general_section().get("formline").unwrap_or("2").parse::<f64>().unwrap_or(2.0);
     let jarkkos_bug: bool = conf.general_section().get("jarkkos2019").unwrap_or("0") == "1";
-
+    let contour_intervall: f64 = conf.general_section().get("contour_intervall").unwrap_or("5").parse::<f64>().unwrap_or(5.0);
+    let halfintervall = contour_intervall / 2.0 * scalefactor;
     if formline > 0.0 {
-        indexcontours = 25.0;
+        indexcontours = 5.0 * contour_intervall;
     }
 
-    let interval = 2.5 * scalefactor;
+    let interval = 2.5 * halfintervall;
     let path = format!("{}/xyz_knolls.xyz", tmpfolder);
     let xyz_file_in = Path::new(&path);
     let mut size: f64 = f64::NAN;


### PR DESCRIPTION
Original Pullauta has 5m contour interval as standard. This pull request introduces the feature to choose contour intervall through the parameter contour_intervall in the .ini-file. 

Changes done to the script:
Introduction of parameter contour_intervall, default parameter 5

In script - 
changed smoothejoin to have index contours every 5th standard contour and xyz2contours to set input to half the contour_intervall. And set recognition of contour type based on right intervall.

I assumed that now only the main.rs needed to be changes. Let me know if I need to change the other files or run the pack-windows-exe.bat also. Then I will redo and post a new pull request. It is better I learn so I can make it easier for coming proposed updates. 