### PR TITLE
Replace contour `HashMap` keys with integer tuples instead of `Strings`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4461,20 +4461,20 @@ fn check_obj_in(
         let key = (x1, y1, 1);
         if !curves.contains_key(&key) {
             curves.insert(key, (x2, y2));
-            obj.push(key.clone());
+            obj.push(key);
         } else {
             let key = (x1, y1, 2);
-            curves.insert(key.clone(), (x2, y2));
-            obj.push(key.clone());
+            curves.insert(key, (x2, y2));
+            obj.push(key);
         }
         let key = (x2, y2, 1);
         if !curves.contains_key(&key) {
-            curves.insert(key.clone(), (x1, y1));
-            obj.push(key.clone());
+            curves.insert(key, (x1, y1));
+            obj.push(key);
         } else {
             let key = (x2, y2, 2);
-            curves.insert(key.clone(), (x1, y1));
-            obj.push(key.clone());
+            curves.insert(key, (x1, y1));
+            obj.push(key);
         }
     }
 }


### PR DESCRIPTION
Some small changes to improve execution time and memory usage for the `xyz2contours` function even further!

* Changed the keys in the `obj` and `curves` `HashMap` to be tuples of `(i64,i64,u8)` instead of strings that needed to be formatted and split on every iteration. Since this is quite a hot code-path it improves both memory usage (needed allocations on the heap) and runtime (less operations to perform) :rocket: 
* Changed to use the more efficient `read_lines_no_alloc` function when converting the result of the curve generation.
* Improved file handling to not open and close the file on every iteration since lines were only appended anyways.
* Instead of reading in all the points and storing them for later computing the average of each cell, we now only store the sum and the count. This leads to a  substantial reduction in memory usage during this part of the processing. On my tests down ca 100MB :+1: 